### PR TITLE
Docker support added to the project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM i386/debian
 
-WORKDIR /opt/cpp/app
+WORKDIR /app
 
 RUN apt update && apt install gcc make flex bison nasm git g++ -y
 
-CMD make clean && make test
+# Interactive mode
+CMD bash
+
+# Running tests
+# CMD make clean && make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM i386/debian
+
+WORKDIR /opt/cpp/app
+
+RUN apt update && apt install gcc make flex bison nasm git g++ -y
+
+CMD make clean && make test

--- a/README.md
+++ b/README.md
@@ -46,11 +46,19 @@ To run the executable output:
 
 ## Docker environment
 
-If you don't want to compile with your local environment, there is a Docker option. Use the following command in the project root to start and run the Docker image:
+If you don't want to compile with your local environment, there is a Docker option. Use the following commands in the project root to build and run the Docker image:
+
 ```
-docker-compose up --build
+docker-compose build
+docker-compose run compiler-env
 ```
 
+This will open a bash terminal on the image. All the source files is in the working directory and it can be modify on the host operating system too. The working directory is shared between the host and the container.
+
+To exit the interactive terminal use:
+```
+exit
+```
 To stop and remove the environment run:
 ```
 docker-compose down

--- a/README.md
+++ b/README.md
@@ -44,5 +44,31 @@ To run the executable output:
 ./output
 ```
 
+## Docker environment
+
+If you don't want to compile with your local environment, there is a Docker option. Use the following command in the project root to start and run the Docker image:
+```
+docker-compose up --build
+```
+
+To stop and remove the environment run:
+```
+docker-compose down
+```
+
+## Known Issues
+
+If you clone the repository on Windows, the line endings will be converted to Windows format, therefore the compiler not run. Expected error message:
+
+```
+'.mpilerEnv     | Line 1: Unexpected character: '
+CompilerEnv     | Makefile:51: recipe for target 'exec_write_natural' failed
+CompilerEnv     | make: *** [exec_write_natural] Error 1
+```
+
+### Solution
+
+Download the repository as a Zip file and unpack it. This keeps the file endings as is, not changing to Windows format.
+
 ## License
 This software is licensed under the MIT license. See the *LICENSE* file for details.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  compiler-env:
+    build: ./
+    container_name: CompilerEnv
+    volumes:
+      - ./:/app
+    working_dir: /app
+    stdin_open: true
+    tty: true


### PR DESCRIPTION
Gyakorlati órán felmerültek problémák a kód futtatásának kapcsán, ezért készítettem egy Docker konténert ahol egységes környezetet lehet garantálni a fordítónak. A konténer egy 32-bites Debian rendszer, ezért még a -m32 kapcsoló sem fog kelleni, így a make fájlt sem kell megváltoztatni. Továbbá az egyik hibát is felírtam a README fájlba.