### PR TITLE
Fix exit call

### DIFF
--- a/implementation.cc
+++ b/implementation.cc
@@ -1,12 +1,13 @@
 #include "implementation.hh"
 #include <iostream>
 #include <sstream>
+#include <cstdlib>
 
 mode current_mode;
 
 void error(int line, std::string text) {
     std::cerr << "Line " << line << ": Error: " << text << std::endl;
-    exit(1);
+    std::exit(1);
 }
 
 expression::~expression() {


### PR DESCRIPTION
The `exit` function (symbol) was not declared in the given context.
Including the necessary header file resolves the issue, and draws the project compilable.

At the same time, since the source file is C++, I'm using the C++ version of the function (`std::exit`).