### PR TITLE
Update gitignore to ignore generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+lex.yy.cc
+location.hh
+position.hh
+stack.hh
+while
+while.tab.cc
+while.tab.hh
+temp*


### PR DESCRIPTION
The generated files would show up as *unstaged* in git. To prevent people from accidentally committing such files, it is useful to mark them ignored.